### PR TITLE
Feature implementation from commits 9386e68..58e145a

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,20 +18,20 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint-fix
         args: [-c, configs/.markdownlint.yaml, --fix, --disable, MD028]
         exclude: ^marimo/_tutorials/.*\.md
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.31.1
+    rev: v1
     hooks:
       - id: typos
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.13
     hooks:
       # Run the linter
       - id: ruff
@@ -40,7 +40,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.0.0-beta.6
+    rev: v2.0.0-beta.5
     hooks:
       - id: biome-check
         args: [--config-path, biome.jsonc, --diagnostic-level, warn]

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "frontend/node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
-    "includes": ["frontend/src/**/*", "!*.json"]
+    "includes": ["frontend/src/**/*", "openapi/**/*", "lsp/**/*", "!*.json"]
   },
   "formatter": {
     "indentStyle": "space",

--- a/frontend/src/components/chat/markdown-renderer.tsx
+++ b/frontend/src/components/chat/markdown-renderer.tsx
@@ -4,7 +4,7 @@ import { EditorView } from "@codemirror/view";
 import { useAtomValue } from "jotai";
 import { BetweenHorizontalStartIcon } from "lucide-react";
 import { marked } from "marked";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, Suspense, useEffect, useMemo, useState } from "react";
 import Markdown, { type Components } from "react-markdown";
 import { Button, type ButtonProps } from "@/components/ui/button";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
@@ -110,17 +110,19 @@ const CodeBlock = ({ code, language }: CodeBlockProps) => {
 
   return (
     <div className="relative">
-      <LazyAnyLanguageCodeMirror
-        theme={theme === "dark" ? "dark" : "light"}
-        // Only show the language if it's supported
-        language={
-          language && SUPPORTED_LANGUAGES.has(language) ? language : undefined
-        }
-        className="cm border rounded overflow-hidden"
-        extensions={extensions}
-        value={value}
-        onChange={setValue}
-      />
+      <Suspense>
+        <LazyAnyLanguageCodeMirror
+          theme={theme === "dark" ? "dark" : "light"}
+          // Only show the language if it's supported
+          language={
+            language && SUPPORTED_LANGUAGES.has(language) ? language : undefined
+          }
+          className="cm border rounded overflow-hidden"
+          extensions={extensions}
+          value={value}
+          onChange={setValue}
+        />
+      </Suspense>
       <div className="flex justify-end mt-2 space-x-2">
         <CopyButton size="xs" variant="outline" onClick={handleCopyCode}>
           Copy

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React from "react";
+import React, { Suspense } from "react";
 import { createBatchedLoader } from "@/plugins/impl/vega/batched";
 import { useTheme } from "@/theme/useTheme";
 import { logNever } from "@/utils/assertNever";
@@ -34,23 +34,26 @@ export const TableColumnSummary = <TData, TValue>({
   const { spec, type, stats } = chartSpecModel.getHeaderSummary(columnId);
   let chart: React.ReactNode = null;
   if (spec) {
+    const skeleton = <ChartSkeleton seed={columnId} width={80} height={40} />;
     chart = (
       <DelayMount
         milliseconds={200}
         visibility={true}
         rootMargin="200px"
-        fallback={<ChartSkeleton seed={columnId} width={80} height={40} />}
+        fallback={skeleton}
       >
-        <LazyVegaLite
-          spec={spec}
-          width={70}
-          height={30}
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          loader={batchedLoader as any}
-          style={{ minWidth: "unset", maxHeight: "40px" }}
-          actions={false}
-          theme={theme === "dark" ? "dark" : "vox"}
-        />
+        <Suspense fallback={skeleton}>
+          <LazyVegaLite
+            spec={spec}
+            width={70}
+            height={30}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            loader={batchedLoader as any}
+            style={{ minWidth: "unset", maxHeight: "40px" }}
+            actions={false}
+            theme={theme === "dark" ? "dark" : "vox"}
+          />
+        </Suspense>
       </DelayMount>
     );
   }

--- a/frontend/src/components/data-table/range-focus/use-cell-range-selection.ts
+++ b/frontend/src/components/data-table/range-focus/use-cell-range-selection.ts
@@ -2,6 +2,7 @@
 
 import type { Cell, Table } from "@tanstack/react-table";
 import useEvent from "react-use-event-hook";
+import { Functions } from "@/utils/functions";
 import { type SelectedCell, useCellSelectionReducerActions } from "./atoms";
 
 export interface UseCellRangeSelectionProps<TData> {
@@ -93,6 +94,18 @@ export const useCellRangeSelection = <TData>({
     },
   );
 
+  if (DISABLED) {
+    return {
+      handleCellMouseDown: Functions.NOOP,
+      handleCellMouseUp: Functions.NOOP,
+      handleCellMouseOver: Functions.NOOP,
+      handleCellsKeyDown: Functions.NOOP,
+      updateSelection: Functions.NOOP,
+      clearSelection: Functions.NOOP,
+      handleCopy: Functions.NOOP,
+    };
+  }
+
   return {
     handleCellMouseDown,
     handleCellMouseUp,
@@ -103,3 +116,5 @@ export const useCellRangeSelection = <TData>({
     clearSelection: actions.clearSelection,
   };
 };
+
+const DISABLED = true;

--- a/frontend/src/components/datasets/icons.tsx
+++ b/frontend/src/components/datasets/icons.tsx
@@ -11,6 +11,7 @@ import {
   TypeIcon,
 } from "lucide-react";
 import type { DataType } from "@/core/kernel/messages";
+import { logNever } from "@/utils/assertNever";
 import type { SelectableDataType } from "../data-table/charts/types";
 
 /**
@@ -29,14 +30,26 @@ export const DATA_TYPE_ICON: Record<DataType | SelectableDataType, LucideIcon> =
     unknown: CurlyBracesIcon,
   };
 
-export const DATA_TYPE_COLOR: Record<DataType | SelectableDataType, string> = {
-  boolean: "bg-[var(--orange-4)]",
-  date: "bg-[var(--grass-4)]",
-  time: "bg-[var(--grass-4)]",
-  datetime: "bg-[var(--grass-4)]",
-  temporal: "bg-[var(--grass-4)]",
-  number: "bg-[var(--purple-4)]",
-  string: "bg-[var(--blue-4)]",
-  integer: "bg-[var(--purple-4)]",
-  unknown: "bg-[var(--slate-4)]",
-};
+export function getDataTypeColor(
+  dataType: DataType | SelectableDataType,
+): string {
+  switch (dataType) {
+    case "boolean":
+      return "bg-[var(--orange-4)]";
+    case "date":
+    case "time":
+    case "datetime":
+    case "temporal":
+      return "bg-[var(--grass-4)] dark:bg-[var(--grass-5)]";
+    case "number":
+    case "integer":
+      return "bg-[var(--purple-4)]";
+    case "string":
+      return "bg-[var(--blue-4)]";
+    case "unknown":
+      return "bg-[var(--slate-4)] dark:bg-[var(--slate-6)]";
+    default:
+      logNever(dataType);
+      return "bg-[var(--slate-4)] dark:bg-[var(--slate-6)]";
+  }
+}

--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -192,6 +192,7 @@ export function renderChart(chartSpec: string, theme: Theme) {
   const updateSpec = (spec: TopLevelFacetedUnitSpec) => {
     return {
       ...spec,
+      background: "transparent",
       config: { ...spec.config, background: "transparent" },
     };
   };

--- a/frontend/src/components/datasources/components.tsx
+++ b/frontend/src/components/datasources/components.tsx
@@ -3,7 +3,7 @@
 import { ChevronRightIcon, LoaderCircle, XIcon } from "lucide-react";
 import type { DataType } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
-import { DATA_TYPE_COLOR, DATA_TYPE_ICON } from "../datasets/icons";
+import { DATA_TYPE_ICON, getDataTypeColor } from "../datasets/icons";
 
 export const RotatingChevron: React.FC<{ isExpanded: boolean }> = ({
   isExpanded,
@@ -87,11 +87,13 @@ export const ColumnName = ({
   dataType: DataType;
 }) => {
   const Icon = DATA_TYPE_ICON[dataType];
-  const color = DATA_TYPE_COLOR[dataType];
+  const color = getDataTypeColor(dataType);
 
   return (
     <div className="flex flex-row items-center gap-1.5">
-      <Icon className={`w-4 h-4 p-0.5 rounded-sm stroke-black ${color}`} />
+      <Icon
+        className={`w-4 h-4 p-0.5 rounded-sm stroke-card-foreground ${color}`}
+      />
       {columnName}
     </div>
   );

--- a/frontend/src/components/editor/RecoveryButton.tsx
+++ b/frontend/src/components/editor/RecoveryButton.tsx
@@ -46,6 +46,7 @@ const RecoveryModal = (props: {
           id: cell.id,
           name: cell.name,
           code: cell.code,
+          code_hash: null,
           config: {
             column: 0,
             ...cell.config,

--- a/frontend/src/components/editor/cell/useRunCells.ts
+++ b/frontend/src/components/editor/cell/useRunCells.ts
@@ -55,7 +55,7 @@ function useRunCells() {
     const codes: string[] = [];
     for (const cellId of cellIds) {
       const ref = cellHandles[cellId];
-      const ev = ref.current?.editorView;
+      const ev = ref?.current?.editorView;
       let code: string;
       // Performs side-effects that must run whenever the cell is run, but doesn't
       // actually run the cell.
@@ -68,7 +68,7 @@ function useRunCells() {
         // Prefer code from editor
         code = getEditorCodeAsPython(ev);
       } else {
-        code = cellData[cellId].code;
+        code = cellData[cellId]?.code || "";
       }
 
       codes.push(code);

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -176,15 +176,17 @@ const SnippetViewer: React.FC<{ snippet: Snippet }> = ({ snippet }) => {
                   </Button>
                 </Tooltip>
               </HideInKioskMode>
-              <LazyAnyLanguageCodeMirror
-                key={`${snippet.title}-${id}`}
-                theme={theme === "dark" ? "dark" : "light"}
-                language="python"
-                className="cm border rounded overflow-hidden"
-                extensions={extensions}
-                value={code}
-                readOnly={true}
-              />
+              <Suspense>
+                <LazyAnyLanguageCodeMirror
+                  key={`${snippet.title}-${id}`}
+                  theme={theme === "dark" ? "dark" : "light"}
+                  language="python"
+                  className="cm border rounded overflow-hidden"
+                  extensions={extensions}
+                  value={code}
+                  readOnly={true}
+                />
+              </Suspense>
             </div>
           );
         })}

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/backend-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/backend-status.tsx
@@ -7,6 +7,7 @@ import type React from "react";
 import { Spinner } from "@/components/icons/spinner";
 import { connectionAtom } from "@/core/network/connection";
 import { useRuntimeManager } from "@/core/runtime/config";
+import { isWasm } from "@/core/wasm/utils";
 import { WebSocketState } from "@/core/websocket/types";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { useInterval } from "@/hooks/useInterval";
@@ -21,6 +22,14 @@ export const BackendConnection: React.FC = () => {
   const { isFetching, error, data, refetch } = useAsyncData(async () => {
     if (connection !== WebSocketState.OPEN) {
       return;
+    }
+
+    if (isWasm()) {
+      return {
+        isHealthy: true,
+        lastChecked: new Date(),
+        error: undefined,
+      };
     }
 
     try {

--- a/frontend/src/components/editor/controls/Controls.tsx
+++ b/frontend/src/components/editor/controls/Controls.tsx
@@ -15,6 +15,7 @@ import { ShutdownButton } from "@/components/editor/controls/shutdown-button";
 import { Button } from "@/components/editor/inputs/Inputs";
 import { FindReplace } from "@/components/find-replace/find-replace";
 import type { AppConfig } from "@/core/config/config-schema";
+import { isConnectedAtom } from "@/core/network/connection";
 import { SaveComponent } from "@/core/saving/save-component";
 import { cn } from "@/utils/cn";
 import { Functions } from "@/utils/functions";
@@ -137,6 +138,8 @@ const RunControlButton = ({
   needsRun: boolean;
   onRun: () => void;
 }) => {
+  const isConnected = useAtomValue(isConnectedAtom);
+
   if (needsRun) {
     return (
       <Tooltip content={renderShortcut("global.runStale")}>
@@ -161,6 +164,7 @@ const RunControlButton = ({
         color="disabled"
         size="medium"
         shape="circle"
+        disabled={!isConnected}
       >
         <PlayIcon strokeWidth={1.5} size={16} />
       </Button>

--- a/frontend/src/components/editor/file-tree/file-viewer.tsx
+++ b/frontend/src/components/editor/file-tree/file-viewer.tsx
@@ -9,7 +9,7 @@ import {
   SaveIcon,
 } from "lucide-react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { renderShortcut } from "@/components/shortcuts/renderShortcut";
 import { Tooltip } from "@/components/ui/tooltip";
 import { hotkeysAtom } from "@/core/config/config";
@@ -207,30 +207,32 @@ export const FileViewer: React.FC<Props> = ({ file, onOpenNotebook }) => {
     <>
       {header}
       <div className="flex-1 overflow-auto">
-        <LazyAnyLanguageCodeMirror
-          theme={theme === "dark" ? "dark" : "light"}
-          language={mimeToLanguage[mimeType] || mimeToLanguage.default}
-          className="border-b"
-          extensions={[
-            EditorView.lineWrapping,
-            // Command S for save
-            keymap.of([
-              {
-                key: hotkeys.getHotkey("global.save").key,
-                stopPropagation: true,
-                run: () => {
-                  if (internalValue !== data.contents) {
-                    handleSaveFile();
-                    return true;
-                  }
-                  return false;
+        <Suspense>
+          <LazyAnyLanguageCodeMirror
+            theme={theme === "dark" ? "dark" : "light"}
+            language={mimeToLanguage[mimeType] || mimeToLanguage.default}
+            className="border-b"
+            extensions={[
+              EditorView.lineWrapping,
+              // Command S for save
+              keymap.of([
+                {
+                  key: hotkeys.getHotkey("global.save").key,
+                  stopPropagation: true,
+                  run: () => {
+                    if (internalValue !== data.contents) {
+                      handleSaveFile();
+                      return true;
+                    }
+                    return false;
+                  },
                 },
-              },
-            ]),
-          ]}
-          value={internalValue}
-          onChange={setInternalValue}
-        />
+              ]),
+            ]}
+            value={internalValue}
+            onChange={setInternalValue}
+          />
+        </Suspense>
       </div>
     </>
   );

--- a/frontend/src/components/editor/output/JsonOutput.tsx
+++ b/frontend/src/components/editor/output/JsonOutput.tsx
@@ -128,8 +128,9 @@ export const JsonOutput: React.FC<Props> = memo(
             collapseStringsAfterLength={COLLAPSED_TEXT_LENGTH}
             // leave the default valueTypes as it was - 'python', only 'json' is changed
             valueTypes={valueTypesMap[valueTypes]}
-            // disable array grouping (it's misleading) by using a large value
-            groupArraysAfterLength={1_000_000}
+            // When the number of elements exceed 50, we group them in sizes of 50
+            // This improves perf but may look like there are nested arrays
+            groupArraysAfterLength={50}
             // Built-in clipboard shifts content on hover
             // so we provide our own copy button
             enableClipboard={false}

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -23,6 +23,7 @@ import type { CellId } from "@/core/cells/ids";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/languages/sql";
 import { aiEnabledAtom, autoInstantiateAtom } from "@/core/config/config";
+import { isConnectedAtom } from "@/core/network/connection";
 import { useBoolean } from "@/hooks/useBoolean";
 import { cn } from "@/utils/cn";
 import { Functions } from "@/utils/functions";
@@ -295,6 +296,7 @@ const AddCellButtons: React.FC<{
   const autoInstantiate = useAtomValue(autoInstantiateAtom);
   const [isAiButtonOpen, isAiButtonOpenActions] = useBoolean(false);
   const aiEnabled = useAtomValue(aiEnabledAtom);
+  const isConnected = useAtomValue(isConnectedAtom);
 
   const buttonClass = cn(
     "mb-0 rounded-none sm:px-4 md:px-5 lg:px-8 tracking-wide no-wrap whitespace-nowrap",
@@ -312,6 +314,7 @@ const AddCellButtons: React.FC<{
           className={buttonClass}
           variant="text"
           size="sm"
+          disabled={!isConnected}
           onClick={() =>
             createNewCell({
               cellId: { type: "__end__", columnId },
@@ -326,6 +329,7 @@ const AddCellButtons: React.FC<{
           className={buttonClass}
           variant="text"
           size="sm"
+          disabled={!isConnected}
           onClick={() => {
             maybeAddMarimoImport(autoInstantiate, createNewCell);
 
@@ -343,6 +347,7 @@ const AddCellButtons: React.FC<{
           className={buttonClass}
           variant="text"
           size="sm"
+          disabled={!isConnected}
           onClick={() => {
             maybeAddMarimoImport(autoInstantiate, createNewCell);
 
@@ -367,7 +372,7 @@ const AddCellButtons: React.FC<{
             className={buttonClass}
             variant="text"
             size="sm"
-            disabled={!aiEnabled}
+            disabled={!aiEnabled || !isConnected}
             onClick={isAiButtonOpenActions.toggle}
           >
             <SparklesIcon className="mr-2 size-4 flex-shrink-0" />

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -9,7 +9,7 @@ import {
   PlayIcon,
 } from "lucide-react";
 import type React from "react";
-import { useRef, useState } from "react";
+import { Suspense, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import {
   SCRATCH_CELL_ID,
@@ -187,17 +187,19 @@ export const ScratchPad: React.FC = () => {
               className="border rounded-md hover:shadow-sm cursor-pointer hover:border-input overflow-hidden"
               onClick={() => handleSelectHistoryItem(item)}
             >
-              <LazyAnyLanguageCodeMirror
-                language="python"
-                theme={theme}
-                basicSetup={{
-                  highlightActiveLine: false,
-                  highlightActiveLineGutter: false,
-                }}
-                value={item.trim()}
-                editable={false}
-                readOnly={true}
-              />
+              <Suspense>
+                <LazyAnyLanguageCodeMirror
+                  language="python"
+                  theme={theme}
+                  basicSetup={{
+                    highlightActiveLine: false,
+                    highlightActiveLineGutter: false,
+                  }}
+                  value={item.trim()}
+                  editable={false}
+                  readOnly={true}
+                />
+              </Suspense>
             </div>
           ))}
         </div>

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -67,7 +67,7 @@ export const ScratchPad: React.FC = () => {
   const history = useAtomValue(scratchpadHistoryAtom);
 
   const handleRun = useEvent(() => {
-    sendRunScratchpad({ code });
+    void sendRunScratchpad({ code });
     addToHistory(code);
   });
 
@@ -88,7 +88,7 @@ export const ScratchPad: React.FC = () => {
       code: "",
       formattingChange: false,
     });
-    sendRunScratchpad({ code: "" });
+    void sendRunScratchpad({ code: "" });
     const ev = ref.current;
     if (ev) {
       ev.dispatch({

--- a/frontend/src/components/tracing/tracing.tsx
+++ b/frontend/src/components/tracing/tracing.tsx
@@ -10,7 +10,7 @@ import {
   CirclePlayIcon,
   CircleX,
 } from "lucide-react";
-import React, { type JSX, useRef, useState } from "react";
+import React, { type JSX, Suspense, useRef, useState } from "react";
 import type { SignalListeners, VisualizationSpec } from "react-vega";
 import useResizeObserver from "use-resize-observer";
 import { compile } from "vega-lite";
@@ -123,14 +123,16 @@ const Chart: React.FC<ChartProps> = (props: ChartProps) => {
   const { ref, width = 300 } = useResizeObserver<HTMLDivElement>();
   return (
     <div className={props.className} ref={ref}>
-      <LazyVega
-        spec={props.vegaSpec}
-        theme={props.theme === "dark" ? "dark" : undefined}
-        width={width - 50}
-        height={props.height}
-        signalListeners={props.signalListeners}
-        actions={false}
-      />
+      <Suspense>
+        <LazyVega
+          spec={props.vegaSpec}
+          theme={props.theme === "dark" ? "dark" : undefined}
+          width={width - 50}
+          height={props.height}
+          signalListeners={props.signalListeners}
+          actions={false}
+        />
+      </Suspense>
     </div>
   );
 };

--- a/frontend/src/core/cells/__tests__/session.test.ts
+++ b/frontend/src/core/cells/__tests__/session.test.ts
@@ -40,9 +40,10 @@ describe("notebookStateFromSession", () => {
     id: string,
     outputs: SessionCell["outputs"] = [],
     console: SessionCell["console"] = [],
+    code_hash: string | null = null,
   ): SessionCell => ({
     id,
-    code_hash: null,
+    code_hash,
     outputs,
     console,
   });
@@ -52,9 +53,11 @@ describe("notebookStateFromSession", () => {
     code: string | null = null,
     name: string | null = null,
     config: NotebookCell["config"] | null = null,
+    code_hash: string | null = null,
   ): NotebookCell => ({
     id,
     code,
+    code_hash: code_hash,
     name,
     config: {
       column: config?.column ?? null,
@@ -91,10 +94,15 @@ describe("notebookStateFromSession", () => {
 
       const result = notebookStateFromSession(session, notebook);
 
-      expect(Logger.error).toHaveBeenCalledWith(
-        "Session and notebook must have the same cells if both are provided",
+      expect(Logger.warn).toHaveBeenCalledWith(
+        "Session and notebook have different cells, attempted merge.",
       );
-      expect(result).toBeNull();
+      // Should have the same cell structure as notebook
+      expect(result).not.toBeNull();
+      invariant(result, "result is null");
+      expect(result.cellIds.inOrderIds).toEqual(
+        MultiColumn.from([["cell-2"]]).inOrderIds,
+      );
     });
   });
 
@@ -125,7 +133,7 @@ describe("notebookStateFromSession", () => {
       expect(result.cellIds.inOrderIds).toEqual(
         MultiColumn.from([[CELL_1]]).inOrderIds,
       );
-      expect(result.cellData[CELL_1]).toBeUndefined();
+      expect(result.cellData[CELL_1].code).toBe("");
       expect(result.cellRuntime[CELL_1]).toBeDefined();
     });
 
@@ -141,7 +149,10 @@ describe("notebookStateFromSession", () => {
       expect(result.cellIds.inOrderIds).toEqual(
         MultiColumn.from([["cell-1", "cell-2"]]).inOrderIds,
       );
-      expect(Object.keys((result as any).cellData)).toEqual([]);
+      expect(Object.keys((result as any).cellData)).toEqual([
+        "cell-1",
+        "cell-2",
+      ]);
       expect(Object.keys((result as any).cellRuntime)).toEqual([
         "cell-1",
         "cell-2",
@@ -310,6 +321,7 @@ describe("notebookStateFromSession", () => {
         id: "cell-1",
         code: null,
         name: null,
+        code_hash: null,
         config: {
           hide_code: null,
           disabled: null,
@@ -551,6 +563,195 @@ describe("notebookStateFromSession", () => {
       expect(result.history).toEqual([]);
       expect(result.scrollKey).toBeNull();
       expect(result.cellLogs).toEqual([]);
+    });
+  });
+
+  describe("session and notebook merge with code values abcdef", () => {
+    it("merges session and notebook with code values a-f and correct hashes", () => {
+      // md5 hashes for 'a' through 'f'
+      const hashes = {
+        a: "0cc175b9c0f1b6a831c399e269772661",
+        b: "92eb5ffee6ae2fec3ad71c777531578f",
+        c: "4a8a08f09d37b73795649038408b5f33",
+        d: "8277e0910d750195b448797616e091ad",
+        e: "e1671797c52e15f763380b45e841ec32",
+        f: "8fa14cdd754f91cc6554c9e71929cce7",
+      };
+      // Create notebook cells with code values 'a' through 'f'
+      const notebookCells = [
+        createNotebookCell("cell-a", "a", null, null, hashes.a),
+        createNotebookCell("cell-b", "b", null, null, hashes.b),
+        createNotebookCell("cell-c", "c", null, null, hashes.c),
+        createNotebookCell("cell-d", "d", null, null, hashes.d),
+        createNotebookCell("cell-e", "e", null, null, hashes.e),
+        createNotebookCell("cell-f", "f", null, null, hashes.f),
+      ];
+      // Create session cells with matching code_hashes
+      const sessionCells = [
+        createSessionCell(
+          "cell-a",
+          [{ type: "data", data: { "text/plain": "A!" } }],
+          [],
+          hashes.a,
+        ),
+        createSessionCell(
+          "cell-b",
+          [{ type: "data", data: { "text/plain": "B!" } }],
+          [],
+          hashes.b,
+        ),
+        createSessionCell(
+          "cell-c",
+          [{ type: "data", data: { "text/plain": "C!" } }],
+          [],
+          hashes.c,
+        ),
+        createSessionCell(
+          "cell-d",
+          [{ type: "data", data: { "text/plain": "D!" } }],
+          [],
+          hashes.d,
+        ),
+        createSessionCell(
+          "cell-e",
+          [{ type: "data", data: { "text/plain": "E!" } }],
+          [],
+          hashes.e,
+        ),
+        createSessionCell(
+          "cell-f",
+          [{ type: "data", data: { "text/plain": "F!" } }],
+          [],
+          hashes.f,
+        ),
+      ];
+      const session = createSession(sessionCells);
+      const notebook = createNotebook(notebookCells);
+      const result = notebookStateFromSession(session, notebook);
+      expect(result).not.toBeNull();
+      invariant(result, "result is null");
+      // Should have all cell IDs in order
+      expect(result.cellIds.inOrderIds).toEqual(
+        MultiColumn.from([
+          ["cell-a", "cell-b", "cell-c", "cell-d", "cell-e", "cell-f"],
+        ]).inOrderIds,
+      );
+      // Should have correct code and output for each cell
+      for (const code of ["a", "b", "c", "d", "e", "f"]) {
+        const cellId = `cell-${code}` as CellId;
+        expect(result.cellData[cellId].code).toBe(code);
+        expect(result.cellRuntime[cellId].output).toEqual({
+          channel: "output",
+          data: `${code.toUpperCase()}!`,
+          mimetype: "text/plain",
+          timestamp: 0,
+        });
+      }
+    });
+
+    it("merges session and notebook with abcde -> aczeg edit distance scenario", () => {
+      // md5 hashes for the codes
+      const hashes = {
+        a: "0cc175b9c0f1b6a831c399e269772661",
+        b: "92eb5ffee6ae2fec3ad71c777531578f",
+        c: "4a8a08f09d37b73795649038408b5f33",
+        d: "8277e0910d750195b448797616e091ad",
+        e: "e1671797c52e15f763380b45e841ec32",
+        z: "fbade9e36a3f36d3d676c1b808451dd7", // hash for 'z'
+        g: "b2f5ff47436671b6e533d8dc3614845d", // hash for 'g'
+      };
+
+      // Session has cells with code 'a', 'b', 'c', 'd', 'e'
+      const sessionCells = [
+        createSessionCell(
+          "cell-a",
+          [{ type: "data", data: { "text/plain": "A!" } }],
+          [],
+          hashes.a,
+        ),
+        createSessionCell(
+          "cell-b",
+          [{ type: "data", data: { "text/plain": "B!" } }],
+          [],
+          hashes.b,
+        ),
+        createSessionCell(
+          "cell-c",
+          [{ type: "data", data: { "text/plain": "C!" } }],
+          [],
+          hashes.c,
+        ),
+        createSessionCell(
+          "cell-d",
+          [{ type: "data", data: { "text/plain": "D!" } }],
+          [],
+          hashes.d,
+        ),
+        createSessionCell(
+          "cell-e",
+          [{ type: "data", data: { "text/plain": "E!" } }],
+          [],
+          hashes.e,
+        ),
+      ];
+
+      // Notebook has cells with code 'a', 'c', 'z', 'e', 'g'
+      const notebookCells = [
+        createNotebookCell("cell-a", "a", null, null, hashes.a),
+        createNotebookCell("cell-c", "c", null, null, hashes.c),
+        createNotebookCell("cell-z", "z", null, null, hashes.z),
+        createNotebookCell("cell-e", "e", null, null, hashes.e),
+        createNotebookCell("cell-g", "g", null, null, hashes.g),
+      ];
+
+      const session = createSession(sessionCells);
+      const notebook = createNotebook(notebookCells);
+      const result = notebookStateFromSession(session, notebook);
+
+      expect(result).not.toBeNull();
+      invariant(result, "result is null");
+
+      // Should have notebook cell IDs in order (notebook is canonical)
+      expect(result.cellIds.inOrderIds).toEqual(
+        MultiColumn.from([["cell-a", "cell-c", "cell-z", "cell-e", "cell-g"]])
+          .inOrderIds,
+      );
+
+      // Should have correct code for each cell
+      expect(result.cellData["cell-a" as CellId].code).toBe("a");
+      expect(result.cellData["cell-c" as CellId].code).toBe("c");
+      expect(result.cellData["cell-z" as CellId].code).toBe("z");
+      expect(result.cellData["cell-e" as CellId].code).toBe("e");
+      expect(result.cellData["cell-g" as CellId].code).toBe("g");
+
+      // Should have session outputs for matching cells (a, c, e)
+      expect(result.cellRuntime["cell-a" as CellId].output).toEqual({
+        channel: "output",
+        data: "A!",
+        mimetype: "text/plain",
+        timestamp: 0,
+      });
+      expect(result.cellRuntime["cell-c" as CellId].output).toEqual({
+        channel: "output",
+        data: "C!",
+        mimetype: "text/plain",
+        timestamp: 0,
+      });
+      expect(result.cellRuntime["cell-e" as CellId].output).toEqual({
+        channel: "output",
+        data: "E!",
+        mimetype: "text/plain",
+        timestamp: 0,
+      });
+
+      // Should have no output for new cells (z, g) - they get stub session cells
+      expect(result.cellRuntime["cell-z" as CellId].output).toBeNull();
+      expect(result.cellRuntime["cell-g" as CellId].output).toBeNull();
+
+      // Should log warning about different cells
+      expect(Logger.warn).toHaveBeenCalledWith(
+        "Session and notebook have different cells, attempted merge.",
+      );
     });
   });
 });

--- a/frontend/src/core/cells/session.ts
+++ b/frontend/src/core/cells/session.ts
@@ -1,9 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import type * as api from "@marimo-team/marimo-api";
+import { mergeArray } from "@/utils/edit-distance";
 import { MultiColumn } from "@/utils/id-tree";
 import { Logger } from "@/utils/Logger";
-import { Sets } from "@/utils/sets";
 import { parseOutline } from "../dom/outline";
 import { CellId } from "./ids";
 import {
@@ -19,60 +19,133 @@ const EMPTY_STRING = "";
 type SessionCell = api.Session["NotebookSessionV1"]["cells"][0];
 type NotebookCell = api.Notebook["NotebookV1"]["cells"][0];
 
-interface ValidationResult {
-  isValid: boolean;
-  error?: string;
-}
-
-function validateSessionNotebookCompatibility(
+function mergeSessionAndNotebookCells(
   session: api.Session["NotebookSessionV1"] | null | undefined,
   notebook: api.Notebook["NotebookV1"] | null | undefined,
-): ValidationResult {
+): {
+  cellIds: CellId[];
+  sessionCellData: Map<CellId, SessionCell | null>;
+  notebookCellData: Map<CellId, NotebookCell>;
+} {
+  const sessionCellData = new Map<CellId, SessionCell | null>();
+  const notebookCellData = new Map<CellId, NotebookCell>();
+
   if (!session && !notebook) {
+    return { cellIds: [], sessionCellData, notebookCellData };
+  }
+
+  if (!session) {
+    const cellIds = (notebook?.cells.map(
+      (cell) => cell.id ?? CellId.create(),
+    ) || []) as CellId[];
     return {
-      isValid: false,
-      error: "",
+      cellIds,
+      sessionCellData: new Map(
+        cellIds.map((id, idx) => [id, null] as [CellId, SessionCell | null]),
+      ),
+      notebookCellData: new Map(
+        cellIds.map(
+          (id, idx) =>
+            [id, notebook?.cells[idx] || createEmptyNotebookCell()] as [
+              CellId,
+              NotebookCell,
+            ],
+        ),
+      ),
     };
   }
 
-  if (!session || !notebook) {
-    return { isValid: true }; // One is null, which is fine
-  }
-
-  const sessionCellIds = new Set(session.cells.map((cell) => cell.id));
-  const notebookCellIds = new Set(notebook.cells.map((cell) => cell.id));
-
-  // Only check they are equal if both are provided
-  if (
-    sessionCellIds.size > 0 &&
-    notebookCellIds.size > 0 &&
-    !Sets.equals(sessionCellIds, notebookCellIds)
-  ) {
+  if (!notebook) {
+    const cellIds = session.cells.map(
+      (cell) => cell.id ?? CellId.create(),
+    ) as CellId[];
     return {
-      isValid: false,
-      error:
-        "Session and notebook must have the same cells if both are provided",
+      cellIds,
+      sessionCellData: new Map(
+        cellIds.map(
+          (id, idx) => [id, session.cells[idx]] as [CellId, SessionCell | null],
+        ),
+      ),
+      notebookCellData: new Map(
+        cellIds.map(
+          (id) => [id, createEmptyNotebookCell()] as [CellId, NotebookCell],
+        ),
+      ),
     };
   }
 
-  return { isValid: true };
+  // Both session and notebook exist - merge using edit distance on cell content
+  // hash.
+  const { merged: mergedSessionCells, edits } = mergeArray(
+    session.cells,
+    notebook.cells,
+    (sessionCell, notebookCell) => {
+      const sessionCodeHash = sessionCell.code_hash;
+      // If the code hash is null, default to comparing ids
+      if (!sessionCodeHash) {
+        return sessionCell.id === notebookCell.id;
+      }
+      // Compare session cell code_hash with notebook cell code
+      const notebookCodeHash = notebookCell.code_hash;
+      return notebookCodeHash === sessionCodeHash;
+    },
+    // stub cell is empty session cell
+    createEmptySessionCell(),
+  );
+  if (edits.distance > 0) {
+    Logger.warn("Session and notebook have different cells, attempted merge.");
+  }
+
+  // Create merged cell arrays
+  const mergedCellIdsTyped: CellId[] = [];
+
+  // Defer to the notebook cells for the correct ordering.
+  for (let i = 0; i < notebook.cells.length; i++) {
+    const notebookCell = notebook.cells[i];
+    if (notebookCell) {
+      const id = (notebookCell.id ?? CellId.create()) as CellId;
+      mergedCellIdsTyped.push(id);
+
+      // Should always be set, but good typing fallback too.
+      const sessionItem = mergedSessionCells[i] || createEmptySessionCell();
+      sessionItem.id = id; // Ensure session cell has the correct ID
+
+      sessionCellData.set(id, sessionItem);
+      notebookCellData.set(id, notebookCell);
+    } else {
+      // This shouldn't happen since notebook cells are canonical
+      Logger.warn("Merged notebook cell is null at index", i);
+    }
+  }
+
+  return {
+    cellIds: mergedCellIdsTyped,
+    sessionCellData,
+    notebookCellData,
+  };
 }
 
-function getCellIds(
-  session: api.Session["NotebookSessionV1"] | null | undefined,
-  notebook: api.Notebook["NotebookV1"] | null | undefined,
-): CellId[] {
-  // Prefer notebook cells (for ordering) over session cells if both are provided
-  const ids = (notebook?.cells.map((cell) => cell.id) ??
-    session?.cells.map((cell) => cell.id) ??
-    []) as CellId[];
-  // Replace nulls with unique ids.
-  return ids.map((id) => {
-    if (id === null) {
-      return CellId.create();
-    }
-    return id;
-  });
+function createEmptyNotebookCell(): NotebookCell {
+  return {
+    id: CellId.create(),
+    name: EMPTY_STRING,
+    code: EMPTY_STRING,
+    code_hash: null,
+    config: {
+      column: null,
+      disabled: false,
+      hide_code: false,
+    },
+  };
+}
+
+function createEmptySessionCell(): SessionCell {
+  return {
+    id: CellId.create(),
+    code_hash: null,
+    console: [],
+    outputs: [],
+  };
 }
 
 function createCellDataFromNotebook(
@@ -154,31 +227,14 @@ export function notebookStateFromSession(
   session: api.Session["NotebookSessionV1"] | null | undefined,
   notebook: api.Notebook["NotebookV1"] | null | undefined,
 ) {
-  // Validate compatibility
-  const validation = validateSessionNotebookCompatibility(session, notebook);
-  if (!validation.isValid) {
-    if (validation.error) {
-      Logger.error(validation.error);
-    }
-    return null;
-  }
+  // Merge session and notebook cells using edit distance
+  const { cellIds, sessionCellData, notebookCellData } =
+    mergeSessionAndNotebookCells(session, notebook);
 
-  // Get cell IDs
-  const cellIds = getCellIds(session, notebook);
   if (cellIds.length === 0) {
     Logger.warn("Session and notebook must have at least one cell");
     return null;
   }
-
-  // Create lookup maps for efficient access
-  // Replacing with the cellIds fallback.
-  const sessionCellData = new Map(
-    cellIds.map((id, idx) => [id, session?.cells[idx]]),
-  );
-
-  const notebookCellData = new Map(
-    cellIds.map((id, idx) => [id, notebook?.cells[idx]]),
-  );
 
   const cellData: Record<CellId, CellData> = {};
   const cellRuntime: Record<CellId, CellRuntimeState> = {};

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -40,7 +40,7 @@ export const KnownQueryParams = {
   accessToken: "access_token",
   /**
    * Layout view-as. If the editor is in run-mode, this overrides the current
-   * layout view.
+   * layout view. In edit-mode, can be used to start in present mode.
    */
   viewAs: "view-as",
   /**

--- a/frontend/src/core/meta/state.ts
+++ b/frontend/src/core/meta/state.ts
@@ -1,7 +1,22 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { atom } from "jotai";
 
-const BUILD_VERSION: string = import.meta.env.VITE_MARIMO_VERSION || "unknown";
+import { atom } from "jotai";
+import { Logger } from "@/utils/Logger";
+
+function getVersionFromMountConfig(): string | null {
+  try {
+    const mountConfig = window.__MARIMO_MOUNT_CONFIG__ as { version: string };
+    return mountConfig.version;
+  } catch {
+    Logger.warn("Failed to get version from mount config");
+    return null;
+  }
+}
+
+const BUILD_VERSION: string =
+  getVersionFromMountConfig() ||
+  import.meta.env.VITE_MARIMO_VERSION ||
+  "unknown";
 
 export const marimoVersionAtom = atom<string>(BUILD_VERSION);
 

--- a/frontend/src/core/network/connection.ts
+++ b/frontend/src/core/network/connection.ts
@@ -21,3 +21,8 @@ export const isConnectingAtom = atom((get) => {
   const connection = get(connectionAtom);
   return connection.state === WebSocketState.CONNECTING;
 });
+
+export const isConnectedAtom = atom((get) => {
+  const connection = get(connectionAtom);
+  return connection.state === WebSocketState.OPEN;
+});

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -82,14 +82,16 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .POST("/api/kernel/shutdown")
         .then(handleResponseReturnNull);
     },
-    sendRun: (request) => {
+    sendRun: async (request) => {
+      await waitForConnectionOpen();
       return getClient()
         .POST("/api/kernel/run", {
           body: request,
         })
         .then(handleResponseReturnNull);
     },
-    sendRunScratchpad: (request) => {
+    sendRunScratchpad: async (request) => {
+      await waitForConnectionOpen();
       return getClient()
         .POST("/api/kernel/scratchpad/run", {
           body: request,

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -34,7 +34,8 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .POST("/api/kernel/restart_session")
         .then(handleResponseReturnNull);
     },
-    syncCellIds: (request) => {
+    syncCellIds: async (request) => {
+      await waitForConnectionOpen();
       return getClient()
         .POST("/api/kernel/sync/cell_ids", {
           body: request,
@@ -95,7 +96,8 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleResponseReturnNull);
     },
-    sendInstantiate: (request) => {
+    sendInstantiate: async (request) => {
+      await waitForConnectionOpen();
       return getClient()
         .POST("/api/kernel/instantiate", {
           body: request,
@@ -109,7 +111,8 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleResponseReturnNull);
     },
-    sendCodeCompletionRequest: (request) => {
+    sendCodeCompletionRequest: async (request) => {
+      await waitForConnectionOpen();
       return getClient()
         .POST("/api/kernel/code_autocomplete", {
           body: request,

--- a/frontend/src/mount.tsx
+++ b/frontend/src/mount.tsx
@@ -9,6 +9,7 @@ import {
   configOverridesAtom,
   userConfigAtom,
 } from "@/core/config/config";
+import { KnownQueryParams } from "@/core/constants";
 import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
 import { getMarimoCode } from "@/core/meta/globals";
 import {
@@ -273,7 +274,16 @@ function initStore(options: unknown) {
   // Meta
   store.set(marimoVersionAtom, parsedOptions.data.version);
   store.set(showCodeInRunModeAtom, parsedOptions.data.view.showAppCode);
-  store.set(viewStateAtom, { mode, cellAnchor: null });
+
+  // Check for view-as parameter to start in present mode
+  const shouldStartInPresentMode = (() => {
+    const url = new URL(window.location.href);
+    return url.searchParams.get(KnownQueryParams.viewAs) === "present";
+  })();
+
+  const initialViewMode =
+    mode === "edit" && shouldStartInPresentMode ? "present" : mode;
+  store.set(viewStateAtom, { mode: initialViewMode, cellAnchor: null });
   store.set(serverTokenAtom, parsedOptions.data.serverToken);
 
   // Config

--- a/frontend/src/utils/__tests__/edit-distance.test.ts
+++ b/frontend/src/utils/__tests__/edit-distance.test.ts
@@ -1,0 +1,302 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import {
+  applyOperationsWithStub,
+  type EditOperation,
+  editDistance,
+  editDistanceGeneral,
+  mergeArray,
+  OperationType,
+} from "../edit-distance";
+
+describe("editDistance", () => {
+  it("should return distance 0 for identical arrays", () => {
+    const arr1 = ["a", "b", "c"];
+    const arr2 = ["a", "b", "c"];
+    const result = editDistance(arr1, arr2);
+
+    expect(result.distance).toBe(0);
+    expect(result.operations).toHaveLength(3);
+    expect(
+      result.operations.every((op) => op.type === OperationType.MATCH),
+    ).toBe(true);
+  });
+
+  it("should handle empty arrays", () => {
+    const result1 = editDistance([], []);
+    expect(result1.distance).toBe(0);
+    expect(result1.operations).toHaveLength(0);
+
+    const result2 = editDistance(["a"], []);
+    expect(result2.distance).toBe(1);
+    expect(result2.operations).toHaveLength(1);
+    expect(result2.operations[0].type).toBe(OperationType.DELETE);
+
+    const result3 = editDistance([], ["a"]);
+    expect(result3.distance).toBe(1);
+    expect(result3.operations).toHaveLength(1);
+    expect(result3.operations[0].type).toBe(OperationType.INSERT);
+  });
+
+  it("should handle single element differences", () => {
+    const arr1 = ["a", "b", "c"];
+    const arr2 = ["a", "b", "d"];
+    const result = editDistance(arr1, arr2);
+
+    expect(result.distance).toBe(1);
+    expect(result.operations).toHaveLength(3);
+    expect(result.operations[0].type).toBe(OperationType.MATCH);
+    expect(result.operations[1].type).toBe(OperationType.MATCH);
+    expect(result.operations[2].type).toBe(OperationType.SUBSTITUTE);
+  });
+
+  it("should handle insertions and deletions", () => {
+    const arr1 = ["a", "b", "c"];
+    const arr2 = ["a", "x", "b", "c"];
+    const result = editDistance(arr1, arr2);
+
+    expect(result.distance).toBe(1);
+    expect(result.operations).toHaveLength(4);
+    expect(result.operations[0].type).toBe(OperationType.MATCH);
+    expect(result.operations[1].type).toBe(OperationType.INSERT);
+    expect(result.operations[2].type).toBe(OperationType.MATCH);
+    expect(result.operations[3].type).toBe(OperationType.MATCH);
+  });
+
+  it("should work with custom equality function", () => {
+    const arr1 = [
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ];
+    const arr2 = [
+      { id: 1, name: "a" },
+      { id: 3, name: "c" },
+    ];
+
+    const result = editDistanceGeneral(arr1, arr2, (a, b) => a.id === b.id);
+
+    expect(result.distance).toBe(1);
+    expect(result.operations).toHaveLength(2);
+    expect(result.operations[0].type).toBe(OperationType.MATCH);
+    expect(result.operations[1].type).toBe(OperationType.SUBSTITUTE);
+  });
+
+  // Test the specific example mentioned by the user
+  it("should handle the specific example: abcde -> aczeg", () => {
+    const arr1 = ["a", "b", "c", "d", "e"];
+    const arr2 = ["a", "c", "z", "e", "g"];
+    const result = editDistance(arr1, arr2);
+
+    expect(result.distance).toBe(3);
+    expect(result.operations).toHaveLength(6);
+
+    // Expected operations: match, delete, match, sub, match, insert
+    expect(result.operations[0].type).toBe(OperationType.MATCH); // 'a'
+    expect(result.operations[1].type).toBe(OperationType.DELETE); // 'b'
+    expect(result.operations[2].type).toBe(OperationType.MATCH); // 'c'
+    expect(result.operations[3].type).toBe(OperationType.SUBSTITUTE); // 'd' -> 'z'
+    expect(result.operations[4].type).toBe(OperationType.MATCH); // 'e'
+    expect(result.operations[5].type).toBe(OperationType.INSERT); // 'g'
+  });
+});
+
+describe("applyOperationsWithStub", () => {
+  it("should apply match operations correctly", () => {
+    const original = ["a", "b", "c"];
+    const operations: EditOperation[] = [
+      { type: OperationType.MATCH, position: 0 },
+      { type: OperationType.MATCH, position: 1 },
+      { type: OperationType.MATCH, position: 2 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("should apply delete operations correctly", () => {
+    const original = ["a", "b", "c"];
+    const operations: EditOperation[] = [
+      { type: OperationType.MATCH, position: 0 },
+      { type: OperationType.DELETE, position: 1 },
+      { type: OperationType.MATCH, position: 2 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    expect(result).toEqual(["a", "c"]);
+  });
+
+  it("should apply insert operations correctly", () => {
+    const original = ["a", "c"];
+    const operations: EditOperation[] = [
+      { type: OperationType.MATCH, position: 0 },
+      { type: OperationType.INSERT, position: 1 },
+      { type: OperationType.MATCH, position: 1 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    expect(result).toEqual(["a", "stub", "c"]);
+  });
+
+  it("should apply substitute operations correctly", () => {
+    const original = ["a", "b", "c"];
+    const operations: EditOperation[] = [
+      { type: OperationType.MATCH, position: 0 },
+      {
+        type: OperationType.SUBSTITUTE,
+        position: 1,
+      },
+      { type: OperationType.MATCH, position: 2 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    expect(result).toEqual(["a", "stub", "c"]);
+  });
+
+  it("should handle complex operations with position offsets", () => {
+    const original = ["a", "b", "c", "d"];
+    const operations: EditOperation[] = [
+      { type: OperationType.MATCH, position: 0 },
+      { type: OperationType.DELETE, position: 1 },
+      { type: OperationType.INSERT, position: 1 },
+      { type: OperationType.MATCH, position: 2 },
+      { type: OperationType.DELETE, position: 3 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    expect(result).toEqual(["a", "stub", "c"]);
+  });
+
+  // Test the specific example mentioned by the user
+  it("should handle the specific example: abcde -> ac_e_ (with stub)", () => {
+    const original = ["a", "b", "c", "d", "e"];
+    const operations: EditOperation[] = [
+      { type: OperationType.MATCH, position: 0 },
+      { type: OperationType.DELETE, position: 1 },
+      { type: OperationType.MATCH, position: 2 },
+      {
+        type: OperationType.SUBSTITUTE,
+        position: 3,
+      },
+      { type: OperationType.MATCH, position: 4 },
+      { type: OperationType.INSERT, position: 5 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "_");
+    expect(result).toEqual(["a", "c", "_", "e", "_"]);
+  });
+
+  it("should handle multiple consecutive operations correctly", () => {
+    const original = ["a", "b", "c"];
+    const operations: EditOperation[] = [
+      { type: OperationType.DELETE, position: 0 },
+      { type: OperationType.INSERT, position: 0 },
+      {
+        type: OperationType.SUBSTITUTE,
+        position: 1,
+      },
+      { type: OperationType.DELETE, position: 2 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    // After DELETE at position 0: ["b", "c"] (offset = -1)
+    // After INSERT at position 0: ["stub", "b", "c"] (offset = 0)
+    // After SUBSTITUTE at position 1: ["stub", "stub", "c"] (offset = 0)
+    // After DELETE at position 2: ["stub", "stub"] (offset = -1)
+    expect(result).toEqual(["stub", "stub"]);
+  });
+
+  it("should handle operations that affect array length", () => {
+    const original = ["a", "b"];
+    const operations: EditOperation[] = [
+      { type: OperationType.INSERT, position: 0 },
+      { type: OperationType.INSERT, position: 1 },
+      { type: OperationType.MATCH, position: 2 },
+      { type: OperationType.MATCH, position: 3 },
+      { type: OperationType.INSERT, position: 4 },
+    ];
+
+    const result = applyOperationsWithStub(original, operations, "stub");
+    // After INSERT at position 0: ["stub", "a", "b"] (offset = 1)
+    // After INSERT at position 1: ["stub", "stub", "a", "b"] (offset = 2)
+    // After MATCH at position 2: ["stub", "stub", "a", "b"] (offset = 2)
+    // After MATCH at position 3: ["stub", "stub", "a", "b"] (offset = 2)
+    // After INSERT at position 4: ["stub", "stub", "a", "b", "stub"] (offset = 3)
+    expect(result).toEqual(["stub", "stub", "a", "b", "stub"]);
+  });
+});
+
+describe("mergeArray", () => {
+  it("should merge arrays with matching elements", () => {
+    const arr1 = ["a", "b", "c"];
+    const arr2 = ["a", "b", "c"];
+    const stub = "stub";
+
+    const result = mergeArray(arr1, arr2, (a, b) => a === b, stub);
+
+    expect(result.merged).toEqual(["a", "b", "c"]);
+    expect(result.edits.distance).toBe(0);
+  });
+
+  it("should merge arrays with different elements", () => {
+    const arr1 = ["a", "b", "c"];
+    const arr2 = ["a", "x", "c"];
+    const stub = "stub";
+
+    const result = mergeArray(arr1, arr2, (a, b) => a === b, stub);
+
+    expect(result.merged).toEqual(["a", "stub", "c"]);
+    expect(result.edits.distance).toBe(1);
+  });
+
+  it("should handle empty arrays", () => {
+    const arr1: string[] = [];
+    const arr2: string[] = [];
+    const stub = "stub";
+
+    const result = mergeArray(arr1, arr2, () => false, stub);
+
+    expect(result.merged).toEqual([]);
+    expect(result.edits.distance).toBe(0);
+  });
+
+  it("should handle one empty array", () => {
+    const arr1 = ["a", "b"];
+    const arr2: string[] = [];
+    const stub = "stub";
+
+    const result = mergeArray(arr1, arr2, () => false, stub);
+
+    expect(result.merged).toEqual([]);
+    expect(result.edits.distance).toBe(2);
+  });
+
+  it("should handle complex merging scenarios", () => {
+    const arr1 = ["a", "b", "c"];
+    const arr2 = ["a", "x", "y", "c"];
+    const stub = "stub";
+
+    const result = mergeArray(arr1, arr2, (a, b) => a === b, stub);
+
+    expect(result.merged).toEqual(["a", "stub", "stub", "c"]);
+    expect(result.edits.distance).toBe(2);
+  });
+
+  it("should handle the specific example: abcde -> aczeg", () => {
+    const arr1 = ["a", "b", "c", "d", "e"];
+    const arr2 = ["a", "c", "z", "e", "g"];
+    const stub = "_";
+
+    const result = mergeArray(arr1, arr2, (a, b) => a === b, stub);
+
+    // For abcde -> aczeg:
+    // a matches a -> keep a
+    // b is deleted -> skip b
+    // c matches c -> keep c
+    // d is substituted with z -> use stub _
+    // e matches e -> keep e
+    // g is inserted -> use stub _
+    expect(result.merged).toEqual(["a", "c", "_", "e", "_"]);
+    expect(result.edits.distance).toBe(3);
+  });
+});

--- a/frontend/src/utils/edit-distance.ts
+++ b/frontend/src/utils/edit-distance.ts
@@ -1,0 +1,141 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+export enum OperationType {
+  INSERT = "insert",
+  DELETE = "delete",
+  SUBSTITUTE = "substitute",
+  MATCH = "match",
+}
+
+export interface EditOperation {
+  type: OperationType;
+  position: number;
+}
+
+export interface EditDistanceResult {
+  distance: number;
+  operations: EditOperation[];
+}
+
+export function editDistanceGeneral<T, U>(
+  arr1: T[],
+  arr2: U[],
+  equals: (a: T, b: U) => boolean,
+): EditDistanceResult {
+  const m: number = arr1.length;
+  const n: number = arr2.length;
+
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    Array.from<number>({ length: n + 1 }).fill(0),
+  );
+
+  for (let i = 0; i <= m; i++) {
+    dp[i][0] = i;
+  }
+  for (let j = 0; j <= n; j++) {
+    dp[0][j] = j;
+  }
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = equals(arr1[i - 1], arr2[j - 1])
+        ? dp[i - 1][j - 1]
+        : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+
+  // Backtrack for operations
+  const operations: EditOperation[] = [];
+  let i: number = m;
+  let j: number = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && equals(arr1[i - 1], arr2[j - 1])) {
+      operations.unshift({
+        type: OperationType.MATCH,
+        position: i - 1,
+      });
+      i--;
+      j--;
+    } else if (i > 0 && j > 0 && dp[i][j] === dp[i - 1][j - 1] + 1) {
+      operations.unshift({
+        type: OperationType.SUBSTITUTE,
+        position: i - 1,
+      });
+      i--;
+      j--;
+    } else if (i > 0 && dp[i][j] === dp[i - 1][j] + 1) {
+      operations.unshift({
+        type: OperationType.DELETE,
+        position: i - 1,
+      });
+      i--;
+    } else if (j > 0 && dp[i][j] === dp[i][j - 1] + 1) {
+      operations.unshift({
+        type: OperationType.INSERT,
+        position: i,
+      });
+      j--;
+    }
+  }
+
+  return { distance: dp[m][n], operations };
+}
+
+export function editDistance<T>(arr1: T[], arr2: T[]): EditDistanceResult {
+  // Default equality check for primitive types
+  const equals = (a: T, b: T): boolean => a === b;
+  return editDistanceGeneral(arr1, arr2, equals);
+}
+
+// Function to apply operations with stub for inserts/substitutions
+export function applyOperationsWithStub<T>(
+  originalArray: T[],
+  operations: EditOperation[],
+  stub: T,
+): T[] {
+  const result: T[] = [];
+  let originalIndex = 0;
+
+  for (const op of operations) {
+    switch (op.type) {
+      case OperationType.MATCH:
+        // Copy the original element
+        result.push(originalArray[originalIndex]);
+        originalIndex++;
+        break;
+
+      case OperationType.DELETE:
+        // Skip the original element (don't add to result)
+        originalIndex++;
+        break;
+
+      case OperationType.INSERT:
+        // Add stub for inserted element
+        result.push(stub);
+        break;
+
+      case OperationType.SUBSTITUTE:
+        // Add stub for substituted element
+        result.push(stub);
+        originalIndex++;
+        break;
+    }
+  }
+
+  return result;
+}
+
+// Generic function to merge cell arrays by code content
+export function mergeArray<T, U>(
+  arr1: T[],
+  arr2: U[],
+  equals: (a: T, b: U) => boolean,
+  stub: T,
+): { merged: Array<T | null>; edits: EditDistanceResult } {
+  const edits = editDistanceGeneral(arr1, arr2, equals);
+  return {
+    merged: applyOperationsWithStub(arr1, edits.operations, stub),
+    edits,
+  };
+}

--- a/lsp/index.test.ts
+++ b/lsp/index.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("LSP Server", () => {
   it("should start and be killable", async () => {

--- a/lsp/index.ts
+++ b/lsp/index.ts
@@ -1,12 +1,12 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
 import type * as http from "node:http";
+import path from "node:path";
+import type * as rpc from "@sourcegraph/vscode-ws-jsonrpc";
+import * as rpcServer from "@sourcegraph/vscode-ws-jsonrpc/lib/server";
 import parseArgs from "minimist";
 import type ws from "ws";
 import { WebSocketServer } from "ws";
-import type * as rpc from "@sourcegraph/vscode-ws-jsonrpc";
-import * as rpcServer from "@sourcegraph/vscode-ws-jsonrpc/lib/server";
-import path from "node:path";
-import fs from "node:fs/promises";
-import fsSync from "node:fs";
 
 const LOG_FILE = path.join(
   process.env.XDG_CACHE_HOME || path.join(process.env.HOME || "", ".cache"),

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -12,6 +12,7 @@ import click
 
 from marimo._cli.print import orange
 from marimo._convert.converters import MarimoConvert
+from marimo._utils.code import hash_code
 
 if TYPE_CHECKING:
     import psutil
@@ -535,7 +536,6 @@ def preview(file_path: Path, port: int, host: str, headless: bool) -> None:
         NotebookSessionMetadata,
         NotebookSessionV1,
     )
-    from marimo._server.export.exporter import hash_code
     from marimo._server.templates.templates import static_notebook_template
     from marimo._server.tokens import SkewProtectionToken
     from marimo._utils.paths import marimo_package_path
@@ -577,8 +577,8 @@ def preview(file_path: Path, port: int, host: str, headless: bool) -> None:
             app_config=_AppConfig(),
             filepath=str(file_path),
             code=code,
-            code_hash=hash_code(code),
             session_snapshot=session_snapshot,
+            code_hash=hash_code(code),
             notebook_snapshot=notebook_snapshot,
             files={},
             asset_url=asset_url,

--- a/marimo/_convert/notebook.py
+++ b/marimo/_convert/notebook.py
@@ -12,6 +12,7 @@ from marimo._schemas.serialization import (
     NotebookSerialization,
     NotebookSerializationV1,
 )
+from marimo._utils.code import hash_code
 
 
 def convert_from_ir_to_notebook_v1(
@@ -31,6 +32,7 @@ def convert_from_ir_to_notebook_v1(
             NotebookCell(
                 id=None,
                 code=data.code,
+                code_hash=hash_code(data.code) if data.code else None,
                 name=data.name,
                 config=NotebookCellConfig(
                     column=data.options.get("column", None),

--- a/marimo/_data/charts.py
+++ b/marimo/_data/charts.py
@@ -12,6 +12,7 @@ import narwhals.stable.v1 as nw
 from marimo._data.models import DataType
 from marimo._utils import assert_never
 from marimo._utils.narwhals_utils import can_narwhalify
+from marimo._utils.theme import get_current_theme
 
 if TYPE_CHECKING:
     import altair as alt
@@ -136,6 +137,7 @@ class NumberChartBuilder(ChartBuilder):
 class StringChartBuilder(ChartBuilder):
     def __init__(self, should_limit_to_10_items: bool) -> None:
         self.should_limit_to_10_items = should_limit_to_10_items
+        self.theme = get_current_theme()
         super().__init__()
 
     def altair(self, data: Any, column: str) -> Any:
@@ -172,8 +174,11 @@ class StringChartBuilder(ChartBuilder):
         )
 
         def add_encodings(chart: alt.Chart) -> alt.Chart:
+            text_color = "white" if self.theme == "dark" else "black"
             _bar_chart = chart.mark_bar(color=STRING_COLOR)
-            _text_chart = chart.mark_text(align="left", dx=3).encode(
+            _text_chart = chart.mark_text(
+                align="left", dx=3, color=text_color
+            ).encode(
                 text=alt.Text("percentage:Q", format=TOOLTIP_PERCENTAGE_FORMAT)
             )
             return _bar_chart + _text_chart  # type: ignore
@@ -238,6 +243,7 @@ class StringChartBuilder(ChartBuilder):
         """
 
     def complex_altair_code(self, data: str, column: str) -> str:
+        text_color = "white" if self.theme == "dark" else "black"
         base_chart_code = dedent(f"""
         _base_chart = (
             alt.Chart({data})
@@ -269,7 +275,7 @@ class StringChartBuilder(ChartBuilder):
         )
 
         _bar_chart = _base_chart.mark_bar(color="{STRING_COLOR}")
-        _text_chart = _base_chart.mark_text(align="left", dx=3).encode(
+        _text_chart = _base_chart.mark_text(align="left", dx=3, color="{text_color}").encode(
             text=alt.Text("percentage:Q", format="{TOOLTIP_PERCENTAGE_FORMAT}")
         )
         """)
@@ -434,7 +440,9 @@ class DateChartBuilder(ChartBuilder):
             opacity=alt.condition(nearest, alt.value(1), alt.value(0)),
         )
 
-        chart = add_common_config(alt.layer(area, points, rule))
+        chart = add_common_config(
+            alt.layer(area, points, rule)
+        ).configure_axis(grid=False)
         return chart
 
     def altair_code(self, data: str, column: str, simple: bool = True) -> str:

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -68,6 +68,26 @@ class Dependency:
         if not self.has():
             message = f"{self.pkg} is required {why}."
             sys.stderr.write(message + "\n\n")
+
+            # NOTE:
+            # If this package is a subpackage (e.g. google.genai),
+            # then we need to invalidate the importlib cache, otherwise Python
+            # will still not be able to import it.
+            #
+            # This only happens in the marimo editor, and not the kernel.
+            # And only happens for subpackages.
+            # .require() is usually followed by an installation, so this is a fine
+            # place to invalidate the cache.
+            if "." in self.pkg:
+                import importlib
+
+                importlib.invalidate_caches()
+                # https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches
+                # > This function should be called if any modules are created/installed while your
+                # > program is running to guarantee all finders will notice the new module's existence.
+                if self.pkg in sys.modules:
+                    del sys.modules[self.pkg]
+
             # Including the `name` helps with auto-installations
             raise ModuleNotFoundError(message, name=self.pkg) from None
 

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -12,7 +12,7 @@ from typing import Callable
 
 from marimo import _loggers
 from marimo._ast.cell import CellConfig
-from marimo._config.config import MarimoConfig
+from marimo._config.config import MarimoConfig, merge_default_config
 from marimo._messaging.types import KernelMessage
 from marimo._pyodide.restartable_task import RestartableTask
 from marimo._pyodide.streams import (
@@ -33,6 +33,7 @@ from marimo._runtime.requests import (
     CodeCompletionRequest,
     ControlRequest,
     SetUIElementValueRequest,
+    SetUserConfigRequest,
 )
 from marimo._runtime.runtime import Kernel
 from marimo._runtime.utils.set_ui_element_request_manager import (
@@ -245,7 +246,8 @@ class PyodideBridge:
 
     def save_user_config(self, request: str) -> None:
         parsed = parse_raw(json.loads(request), requests.SetUserConfigRequest)
-        self.session.put_control_request(parsed)
+        config = merge_default_config(parsed.config)
+        self.session.put_control_request(SetUserConfigRequest(config=config))
 
     def rename_file(self, filename: str) -> None:
         self.session.app_manager.rename(filename)

--- a/marimo/_schemas/generated/notebook.yaml
+++ b/marimo/_schemas/generated/notebook.yaml
@@ -6,6 +6,9 @@ components:
         code:
           nullable: true
           type: string
+        code_hash:
+          nullable: true
+          type: string
         config:
           properties:
             column:
@@ -27,6 +30,7 @@ components:
       required:
       - id
       - code
+      - code_hash
       - name
       - config
       type: object

--- a/marimo/_schemas/notebook.py
+++ b/marimo/_schemas/notebook.py
@@ -24,6 +24,7 @@ class NotebookCell(TypedDict):
 
     id: Optional[str]
     code: Optional[str]
+    code_hash: Optional[str]
     name: Optional[str]
     config: NotebookCellConfig
 

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -52,6 +52,7 @@ from marimo._server.templates.templates import (
 )
 from marimo._server.tokens import SkewProtectionToken
 from marimo._types.ids import CellId_t
+from marimo._utils.code import hash_code
 from marimo._utils.data_uri import build_data_url
 from marimo._utils.marimo_path import MarimoPath
 from marimo._utils.paths import marimo_package_path
@@ -539,12 +540,6 @@ class AutoExporter:
     def cleanup(self) -> None:
         """Cleanup resources"""
         self._executor.shutdown(wait=False)
-
-
-def hash_code(code: str) -> str:
-    import hashlib
-
-    return hashlib.sha256(code.encode("utf-8")).hexdigest()
 
 
 def _create_notebook_cell(

--- a/marimo/_server/session/serialize.py
+++ b/marimo/_server/session/serialize.py
@@ -223,6 +223,7 @@ def serialize_notebook(
             NotebookCell(
                 id=cell_id,
                 code=code,
+                code_hash=_hash_code(code),
                 name=name,
                 config=config,
             )

--- a/marimo/_smoke_tests/tables/complex_types.py
+++ b/marimo/_smoke_tests/tables/complex_types.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.13.14"
+__generated_with = "0.13.15"
 app = marimo.App(width="medium")
 
 
@@ -143,6 +143,30 @@ def _(mo):
     )
     mo.ui.dataframe(pandas_with_timestamp)
     return (pd,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+    ## Stress testing
+
+    We can use a large dataset to stress test our rendering, charting. Notebook credit to Vincent: [WoW Dataset](https://github.com/koaning/wow-avatar-datasets)
+
+    ~36 million rows, 7 columns
+    """
+    )
+    return
+
+
+@app.cell
+def _(pl):
+    wow_data = pl.scan_parquet(
+        "https://github.com/koaning/wow-avatar-datasets/raw/refs/heads/main/wow-full.parquet"
+    )
+    wow_data
+    # wow_data.collect()
+    return
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/tables/rich_elements.py
+++ b/marimo/_smoke_tests/tables/rich_elements.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.11.30"
+__generated_with = "0.13.15"
 app = marimo.App(width="medium")
 
 
@@ -108,6 +108,14 @@ def _(alt, mo, pd):
             "lorem_ipsum_dollar_sit" * 20,
             "lorem_ipsum_dollar_sit" * 20,
         ],
+        "large_array": [
+            [1] * 60,
+            [2] * 60,
+        ],
+        "large_json": [
+            [{"key": i, "value": i} for i in range(60)],
+            [{"key": i, "value": i} for i in range(60)],
+        ],
         "images": [img, html_img],
         "batch": user_info,
         "dropdowns": [
@@ -124,24 +132,7 @@ def _(alt, mo, pd):
     }
 
     mo.vstack([mo.md("## Dictionary"), data])
-    return (
-        chart,
-        chat,
-        data,
-        dictionary,
-        html_img,
-        img,
-        mermaid,
-        office_characters,
-        password,
-        simple_echo_model,
-        source,
-        table,
-        tabs,
-        text,
-        user_info,
-        warn_btn,
-    )
+    return data, password
 
 
 @app.cell
@@ -176,7 +167,7 @@ def _(data, mo, pl):
 
 @app.cell
 def _(mo, password):
-    mo.md(f"### Password value: {password.value}")
+    mo.md(f"""### Password value: {password.value}""")
     return
 
 

--- a/marimo/_utils/code.py
+++ b/marimo/_utils/code.py
@@ -1,0 +1,7 @@
+# Copyright 2025 Marimo. All rights reserved.
+
+
+def hash_code(code: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()

--- a/marimo/_utils/theme.py
+++ b/marimo/_utils/theme.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Marimo. All rights reserved.
+
+from marimo._config.config import Theme
+from marimo._config.manager import get_default_config_manager
+
+
+def get_current_theme() -> Theme:
+    config_manager = get_default_config_manager(current_path=None)
+    return config_manager.theme

--- a/openapi/src/index.ts
+++ b/openapi/src/index.ts
@@ -1,9 +1,9 @@
 export type * from "./api";
-import type { components as session } from "./session";
-import type { components as notebook } from "./notebook";
 
 import createClient, { type ClientOptions } from "openapi-fetch";
 import type { paths } from "./api";
+import type { components as notebook } from "./notebook";
+import type { components as session } from "./session";
 
 export type Session = session["schemas"];
 export type Notebook = notebook["schemas"];

--- a/openapi/src/notebook.ts
+++ b/openapi/src/notebook.ts
@@ -9,6 +9,7 @@ export interface components {
   schemas: {
     NotebookCell: {
       code: string | null;
+      code_hash: string | null;
       config: {
         column?: number | null;
         disabled?: boolean | null;

--- a/tests/_data/snapshots/charts-complex.txt
+++ b/tests/_data/snapshots/charts-complex.txt
@@ -332,7 +332,7 @@ _base_chart = (
 )
 
 _bar_chart = _base_chart.mark_bar(color="#8ec8f6")
-_text_chart = _base_chart.mark_text(align="left", dx=3).encode(
+_text_chart = _base_chart.mark_text(align="left", dx=3, color="black").encode(
     text=alt.Text("percentage:Q", format=".2%")
 )
 
@@ -375,7 +375,7 @@ _base_chart = (
 )
 
 _bar_chart = _base_chart.mark_bar(color="#8ec8f6")
-_text_chart = _base_chart.mark_text(align="left", dx=3).encode(
+_text_chart = _base_chart.mark_text(align="left", dx=3, color="black").encode(
     text=alt.Text("percentage:Q", format=".2%")
 )
 

--- a/tests/_data/snapshots/charts_json.txt
+++ b/tests/_data/snapshots/charts_json.txt
@@ -162,6 +162,9 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.20.1.json",
   "config": {
+    "axis": {
+      "grid": false
+    },
     "view": {
       "continuousHeight": 300,
       "continuousWidth": 300,
@@ -371,6 +374,9 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.20.1.json",
   "config": {
+    "axis": {
+      "grid": false
+    },
     "view": {
       "continuousHeight": 300,
       "continuousWidth": 300,
@@ -580,6 +586,9 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.20.1.json",
   "config": {
+    "axis": {
+      "grid": false
+    },
     "view": {
       "continuousHeight": 300,
       "continuousWidth": 300,
@@ -1051,6 +1060,7 @@
       },
       "mark": {
         "align": "left",
+        "color": "black",
         "dx": 3,
         "type": "text"
       },
@@ -1251,6 +1261,7 @@
       },
       "mark": {
         "align": "left",
+        "color": "black",
         "dx": 3,
         "type": "text"
       },

--- a/tests/_data/snapshots/charts_json_bad_data.txt
+++ b/tests/_data/snapshots/charts_json_bad_data.txt
@@ -140,6 +140,7 @@
       },
       "mark": {
         "align": "left",
+        "color": "black",
         "dx": 3,
         "type": "text"
       },

--- a/tests/_data/snapshots/column_preview_categorical_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_categorical_chart_spec.txt
@@ -130,6 +130,7 @@
       },
       "mark": {
         "align": "left",
+        "color": "black",
         "dx": 3,
         "type": "text"
       },

--- a/tests/_data/snapshots/column_preview_str_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_str_chart_spec.txt
@@ -130,6 +130,7 @@
       },
       "mark": {
         "align": "left",
+        "color": "black",
         "dx": 3,
         "type": "text"
       },

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -63,7 +63,7 @@
             "configOverrides": {"formatting": {"line_length": 100}},
             "appConfig": {"sql_output": "auto", "width": "compact"},
             "view": {"showAppCode": true},
-            "notebook": {"cells": [{"code": "print('Hello, Cell 1')", "config": {}, "id": "cell1", "name": "Cell 1"}, {"code": "print('Hello, Cell 2')", "config": {}, "id": "cell2", "name": "Cell 2"}], "metadata": {"marimo_version": "0.1.0"}, "version": "1"},
+            "notebook": {"cells": [{"code": "print('Hello, Cell 1')", "code_hash": "dd79c4410b5ac8e7ed32b54c7ebd1cda575d9a41770f739b9b8ed19a2a50ff87", "config": {}, "id": "cell1", "name": "Cell 1"}, {"code": "print('Hello, Cell 2')", "code_hash": "9f00c511e0ed7fe6413b8f4d19876bf064117d56109d22d4f8d7f7b1d426c1f9", "config": {}, "id": "cell2", "name": "Cell 2"}], "metadata": {"marimo_version": "0.1.0"}, "version": "1"},
             "session": {"cells": [{"code_hash": "abc123", "console": [{"name": "stdout", "text": "Hello, Cell 1", "type": "stream"}, {"name": "stderr", "text": "Error in Cell 1", "type": "stream"}], "id": "cell1", "outputs": [{"data": {"text/plain": "Hello, Cell 1"}, "type": "data"}]}, {"code_hash": "def456", "console": [], "id": "cell2", "outputs": []}], "metadata": {"marimo_version": "0.1.0"}, "version": "1"},
             "runtimeConfig": null,
         };

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -63,7 +63,7 @@
             "configOverrides": {"formatting": {"line_length": 100}},
             "appConfig": {"sql_output": "auto", "width": "compact"},
             "view": {"showAppCode": true},
-            "notebook": {"cells": [{"code": "print('Hello, Cell 1')", "config": {}, "id": "cell1", "name": "Cell 1"}, {"code": "print('Hello, Cell 2')", "config": {}, "id": "cell2", "name": "Cell 2"}], "metadata": {"marimo_version": "0.1.0"}, "version": "1"},
+            "notebook": {"cells": [{"code": "print('Hello, Cell 1')", "code_hash": "dd79c4410b5ac8e7ed32b54c7ebd1cda575d9a41770f739b9b8ed19a2a50ff87", "config": {}, "id": "cell1", "name": "Cell 1"}, {"code": "print('Hello, Cell 2')", "code_hash": "9f00c511e0ed7fe6413b8f4d19876bf064117d56109d22d4f8d7f7b1d426c1f9", "config": {}, "id": "cell2", "name": "Cell 2"}], "metadata": {"marimo_version": "0.1.0"}, "version": "1"},
             "session": {"cells": [{"code_hash": "abc123", "console": [{"name": "stdout", "text": "Hello, Cell 1", "type": "stream"}, {"name": "stderr", "text": "Error in Cell 1", "type": "stream"}], "id": "cell1", "outputs": [{"data": {"text/plain": "Hello, Cell 1"}, "type": "data"}]}, {"code_hash": "def456", "console": [], "id": "cell2", "outputs": []}], "metadata": {"marimo_version": "0.1.0"}, "version": "1"},
             "runtimeConfig": null,
         };

--- a/tests/_server/templates/test_templates.py
+++ b/tests/_server/templates/test_templates.py
@@ -27,10 +27,10 @@ from marimo._schemas.session import (
     NotebookSessionV1,
     StreamOutput,
 )
-from marimo._server.export.exporter import hash_code
 from marimo._server.model import SessionMode
 from marimo._server.templates import templates
 from marimo._server.tokens import SkewProtectionToken
+from marimo._utils.code import hash_code
 from tests._server.templates.utils import normalize_index_html
 from tests.mocks import snapshotter
 
@@ -370,12 +370,14 @@ class TestStaticNotebookTemplate(unittest.TestCase):
                 NotebookCell(
                     id="cell1",
                     code="print('Hello, Cell 1')",
+                    code_hash=hash_code("print('Hello, Cell 1')"),
                     name="Cell 1",
                     config=NotebookCellConfig(),
                 ),
                 NotebookCell(
                     id="cell2",
                     code="print('Hello, Cell 2')",
+                    code_hash=hash_code("print('Hello, Cell 2')"),
                     name="Cell 2",
                     config=NotebookCellConfig(),
                 ),

--- a/tests/_sql/test_ibis.py
+++ b/tests/_sql/test_ibis.py
@@ -249,7 +249,7 @@ def test_ibis_sql_types() -> None:
         str(dt.String()): "string",
         str(dt.Date()): "date",
         str(dt.Time()): "time",
-        str(dt.Timestamp()): "timestamp",  # duckdb sets default precision
+        str(dt.Timestamp()): "timestamp(6)",  # duckdb sets default precision
         str(dt.Interval(unit="D")): "interval('us')",
         str(dt.Array(value_type=dt.Int32())): "array<int32>",
         str(


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `9386e68..58e145a`
**Files Changed:** 54 (29 programming files)
**Programming Ratio:** 53.7%

**Commits included:**
- fix: reasonable session and notebook merge (#5335)
- tests: fix ibis datatype drift (#5333)
- chore: disable cell range selection for release (#5334)
- Extend `view-as` URI parameter to handle app view in edit mode (#5327)
- fix: invalidate importlib cache after requirecheck fails (#5328)
- fix: dark mode charts and json viewer crashing (#5332)
- fix: merge default config on save_user_config (#5330)
- fix: show wasm always always connected (#5331)
- fix: more Supsense in more places (#5325)
- fix: version init (#5324)
... and 5 more commits